### PR TITLE
Update default.go

### DIFF
--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -10,6 +10,8 @@ package config
 func Default() string {
 	return `# Gaze configuration(priority: default < ~/.gaze.yml < ./.gaze.yaml < -f option)
 commands:
+- ext: .lisp
+  cmd: sbcl --script {{file}}
 - ext: .go
   cmd: go run "{{file}}"
 - ext: .py


### PR DESCRIPTION
Added an entry for invoking sbcl --script for .lisp files.

You could also do .lsp but sbcl users tend to use the full .lisp extension.